### PR TITLE
Ignore second cadence

### DIFF
--- a/data/bluetoothscanner.html
+++ b/data/bluetoothscanner.html
@@ -13,6 +13,7 @@
 <body>
     <fieldset><legend><a href="http://github.com/doudar/SmartSpin2k">http://github.com/doudar/SmartSpin2k</a></legend>
         <p style="text-align: left;"><strong><a href="index.html">Main Index</a></strong></p>
+        <h1><div class="watermark" name = "loadingWatermark" id="loadingWatermark">Loading</div></h1>
     <h1><strong>Select Bluetooth Devices</strong></h1>
     <form action="/send_settings">
         <h2>
@@ -44,6 +45,14 @@
                     <td style="width: 14%; height: 20px;"><select id="bleHRDropdown" name="bleHRDropdown"
                             value="loading"></td>
                 </tr>
+                <tr>
+                    <td>
+                      <p class="tooltip">Double Powermeter Output<span class="tooltiptext">Double Power Output For Certain Pedals</span></p>
+                    </td>
+                    <td>
+                    <label class="switch"><input type="checkbox" name = "doublePower" id="doublePower"><span class="slider"></span></label>
+                    </td>
+                  </tr>
             </tbody>
         </table>
         <input type="submit" value="Save dropdowns for next reboot" />
@@ -79,16 +88,29 @@
                 const data = JSON.parse(this.responseText);
                 let optionPM;
                 optionPM = document.createElement('option');
-                optionPM.text = data.connectedPowerMeter;;
+                optionPM.text = data.connectedPowerMeter;
                 PMDropdown.add(optionPM);
-                for (var key in data) {
-                    if (data[key].UUID == '0x1818') {
+                for (var key in data.connectedPowerMeter) {
+                    if (data.connectedPowerMeter[key].UUID == '0x1818') {
                         optionPM = document.createElement('option');
-                        if (data[key].name) {
-                            optionPM.text = data[key].name;
+                        if (data.connectedPowerMeter[key].name) {
+                            optionPM.text = data.connectedPowerMeter[key].name;
                         }
                         else {
-                            optionPM.text = data[key].address;
+                            optionPM.text = data.connectedPowerMeter[key].address;
+                        }
+                        PMDropdown.add(optionPM);
+                    }
+                }
+                var t_obj = JSON.parse(data.foundDevices)
+                for (var key in t_obj) {
+                    if (t_obj[key].UUID == '0x1818') {
+                        optionPM = document.createElement('option');
+                        if (t_obj[key].name) {
+                            optionPM.text = t_obj[key].name;
+                        }
+                        else {
+                            optionPM.text = t_obj[key].address;
                         }
                         PMDropdown.add(optionPM);
                     }
@@ -98,16 +120,28 @@
                 PMDropdown.add(optionPM);
                 let optionHR;
                 optionHR = document.createElement('option');
-                optionHR.text = data.connectedHeartMonitor;;
+                optionHR.text = data.connectedHeartMonitor;
                 HRDropdown.add(optionHR);
-                for (var key in data) {
-                    if (data[key].UUID == '0x180d') {
+                for (var key in data.connectedHeartMonitor) {
+                    if (data.connectedHeartMonitor[key].UUID == '0x180d') {
                         optionHR = document.createElement('option');
-                        if (data[key].name) {
-                            optionHR.text = data[key].name;
+                        if (data.connectedHeartMonitor[key].name) {
+                            optionHR.text = data.connectedHeartMonitor[key].name;
                         }
                         else {
-                            optionHR.text = data[key].address;
+                            optionHR.text = data.connectedHeartMonitor[key].address;
+                        }
+                        HRDropdown.add(optionHR);
+                    }
+                }
+                for (var key in t_obj) {
+                    if (t_obj[key].UUID == '0x180d') {
+                        optionPM = document.createElement('option');
+                        if (t_obj[key].name) {
+                            optionHR.text = t_obj[key].name;
+                        }
+                        else {
+                            optionHR.text = t_obj[key].address;
                         }
                         HRDropdown.add(optionHR);
                     }
@@ -123,9 +157,12 @@
                 HRDropdown.add(defaultOptionHR);
                 document.getElementById("connectedPowerMeter").innerHTML = data.connectedPowerMeter;
                 document.getElementById("connectedHeartMonitor").innerHTML = data.connectedHeartMonitor;
+                document.getElementById("doublePower").checked = data.doublePower;
+                document.getElementById("loadingWatermark").opacity = 0;
+                setTimeout(function () { document.getElementById("loadingWatermark").remove(); }, 1000);
             }
         };
-        xhttp.open('GET', "/BLEServers", true);
+        xhttp.open('GET', "/configJSON", true);
         xhttp.send();
     }
 

--- a/data/bluetoothscanner.html
+++ b/data/bluetoothscanner.html
@@ -1,68 +1,77 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <style type="text/css">
         html {
-          background-color: #03245c;
-        } 
-            </style>
+            background-color: #03245c;
+        }
+    </style>
     <title>SmartSpin2K Bluetooth Scanner</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 </head>
+
 <body>
-    <fieldset><legend><a href="http://github.com/doudar/SmartSpin2k">http://github.com/doudar/SmartSpin2k</a></legend>
+    <fieldset>
+        <legend><a href="http://github.com/doudar/SmartSpin2k">http://github.com/doudar/SmartSpin2k</a></legend>
         <p style="text-align: left;"><strong><a href="index.html">Main Index</a></strong></p>
-        <h1><div class="watermark" name = "loadingWatermark" id="loadingWatermark">Loading</div></h1>
-    <h1><strong>Select Bluetooth Devices</strong></h1>
-    <form action="/send_settings">
-        <h2>
-        <table>
-            <tbody>
-                <tr style="height: 20px;">
-                    <td style="width: 14%; height: 20px;">
-                        <p><label for="connectedPM">Power Meter:</label></p>
-                    </td>
-                    <td style="width: 14%; height: 20px;"><label id="connectedPowerMeter">loading</label></td>
-                </tr>
-                <tr style="height: 20px;">
-                    <td style="width: 14%; height: 20px;">
-                        <p><label for="connectedHM">Heart Monitor:</label></p>
-                    </td>
-                    <td style="width: 14%; height: 20px;"><label id="connectedHeartMonitor">loading</label></td>
-                </tr>
-                <tr style="height: 20px;">
-                    <td style="width: 14%; height: 20px;">
-                        <p><label for="BluetoothPMDevices">Select New Power Meter:</label></p>
-                    </td>
-                    <td style="width: 14%; height: 20px;"><select id="blePMDropdown" name="blePMDropdown"
-                            value="loading"></td>
-                </tr>
-                <tr style="height: 20px;">
-                    <td style="width: 14%; height: 20px;">
-                        <p><label for="BluetoothHRDevices">Select New Heart Monitor:</label></p>
-                    </td>
-                    <td style="width: 14%; height: 20px;"><select id="bleHRDropdown" name="bleHRDropdown"
-                            value="loading"></td>
-                </tr>
-                <tr>
-                    <td>
-                      <p class="tooltip">Double Powermeter Output<span class="tooltiptext">Double Power Output For Certain Pedals</span></p>
-                    </td>
-                    <td>
-                    <label class="switch"><input type="checkbox" name = "doublePower" id="doublePower"><span class="slider"></span></label>
-                    </td>
-                  </tr>
-            </tbody>
-        </table>
-        <input type="submit" value="Save dropdowns for next reboot" />
-    </form>
-    <p><br></p>
-    <form action="/BLEScan">
-        <input type="submit" value="Scan/Reconnect Devices">
-        <label style="font-size: .75rem; font-style: italic; font-weight: lighter; line-height: .5em;"><br> Hint: you can hold both shifters for 3 seconds <br> to scan/reconnect at anytime without using this page.</label>
-    </form>
-    </h2>
+        <h1>
+            <div class="watermark" name="loadingWatermark" id="loadingWatermark">Loading</div>
+        </h1>
+        <h1><strong>Select Bluetooth Devices</strong></h1>
+        <form action="/send_settings">
+            <h2>
+                <table>
+                    <tbody>
+                        <tr style="height: 20px;">
+                            <td style="width: 14%; height: 20px;">
+                                <p><label for="connectedPM">Power Meter:</label></p>
+                            </td>
+                            <td style="width: 14%; height: 20px;"><label id="connectedPowerMeter">loading</label></td>
+                        </tr>
+                        <tr style="height: 20px;">
+                            <td style="width: 14%; height: 20px;">
+                                <p><label for="connectedHM">Heart Monitor:</label></p>
+                            </td>
+                            <td style="width: 14%; height: 20px;"><label id="connectedHeartMonitor">loading</label></td>
+                        </tr>
+                        <tr style="height: 20px;">
+                            <td style="width: 14%; height: 20px;">
+                                <p><label for="BluetoothPMDevices">Select New Power Meter:</label></p>
+                            </td>
+                            <td style="width: 14%; height: 20px;"><select id="blePMDropdown" name="blePMDropdown"
+                                    value="loading"></td>
+                        </tr>
+                        <tr style="height: 20px;">
+                            <td style="width: 14%; height: 20px;">
+                                <p><label for="BluetoothHRDevices">Select New Heart Monitor:</label></p>
+                            </td>
+                            <td style="width: 14%; height: 20px;"><select id="bleHRDropdown" name="bleHRDropdown"
+                                    value="loading"></td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <p class="tooltip">Double Powermeter Output<span class="tooltiptext">Double Power Output
+                                        For Certain Pedals</span></p>
+                            </td>
+                            <td>
+                                <label class="switch"><input type="checkbox" name="doublePower" id="doublePower"><span
+                                        class="slider"></span></label>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <input type="submit" value="Save dropdowns for next reboot" />
+        </form>
+        <p><br></p>
+        <form action="/BLEScan">
+            <input type="submit" value="Scan/Reconnect Devices">
+            <label style="font-size: .75rem; font-style: italic; font-weight: lighter; line-height: .5em;"><br> Hint:
+                you can hold both shifters for 3 seconds <br> to scan/reconnect at anytime without using this
+                page.</label>
+        </form>
+        </h2>
 </body>
 
 <script>
@@ -102,19 +111,25 @@
                         PMDropdown.add(optionPM);
                     }
                 }
-                var t_obj = JSON.parse(data.foundDevices)
-                for (var key in t_obj) {
-                    if (t_obj[key].UUID == '0x1818') {
-                        optionPM = document.createElement('option');
-                        if (t_obj[key].name) {
-                            optionPM.text = t_obj[key].name;
+                try {
+                    var t_obj = JSON.parse(data.foundDevices)
+                    {
+                        for (var key in t_obj) {
+                            if (t_obj[key].UUID == '0x1818') {
+                                optionPM = document.createElement('option');
+                                if (t_obj[key].name) {
+                                    optionPM.text = t_obj[key].name;
+                                }
+                                else {
+                                    optionPM.text = t_obj[key].address;
+                                }
+                                PMDropdown.add(optionPM);
+                            }
                         }
-                        else {
-                            optionPM.text = t_obj[key].address;
-                        }
-                        PMDropdown.add(optionPM);
                     }
                 }
+                catch (e) { }
+
                 optionPM = document.createElement('option');
                 optionPM.text = 'none';
                 PMDropdown.add(optionPM);
@@ -134,6 +149,7 @@
                         HRDropdown.add(optionHR);
                     }
                 }
+
                 for (var key in t_obj) {
                     if (t_obj[key].UUID == '0x180d') {
                         optionPM = document.createElement('option');

--- a/data/btsimulator.html
+++ b/data/btsimulator.html
@@ -111,9 +111,9 @@
         document.getElementById("hrValue").innerHTML = obj.simulatedHr + " BPM";
         document.getElementById("HRSlider").value = obj.simulatedHr;
         document.getElementById("hroutput").checked = obj.simulateHr;
-        document.getElementById("wattsoutput").checked = obj.simulatePower;
-        document.getElementById("WattsSlider").hidden = !obj.simulatePower;
-        document.getElementById("wattsValue").hidden = !obj.simulatePower;
+        document.getElementById("wattsoutput").checked = obj.doublePower;
+        document.getElementById("WattsSlider").hidden = !obj.doublePower;
+        document.getElementById("wattsValue").hidden = !obj.doublePower;
         document.getElementById("HRSlider").hidden = !obj.simulateHr;
         document.getElementById("hrValue").hidden = !obj.simulateHr;
       }

--- a/include/BLE_Common.h
+++ b/include/BLE_Common.h
@@ -91,11 +91,12 @@ class SpinBLEClient{
     BLEAdvertisedDevice     *myHeartMonitor         = nullptr;
 
     void start();
-    void serverScan(bool connectRequest);
+    void serverScan(bool connectRequest);   
     bool connectToServer();
+    void scanProcess();
 
 private:
-   
+    
     class MyAdvertisedDeviceCallback : public NimBLEAdvertisedDeviceCallbacks
     {
        public:

--- a/include/BLE_Common.h
+++ b/include/BLE_Common.h
@@ -84,6 +84,7 @@ class SpinBLEClient{
     int noReadingIn             = 0;
     int cscCumulativeCrankRev   = 0;
     int cscLastCrankEvtTime     = 0;
+    int lastConnectedPMID       = 0;
 
     BLERemoteCharacteristic *pRemoteCharacteristic  = nullptr;
     BLEAdvertisedDevice     *myPowerMeter           = nullptr;

--- a/include/SmartSpin_parameters.h
+++ b/include/SmartSpin_parameters.h
@@ -22,7 +22,7 @@ class userParameters
     int     stepperPower;
     bool    stealthchop;             
     float   inclineMultiplier;              
-    bool    simulatePower;  //didn't really have a good purpose before, going to be used for HR2VP like calculation              
+    bool    doublePower;  //didn't really have a good purpose before, going to be used for HR2VP like calculation            
     bool    simulateHr;                     
     bool    ERGMode;                      
     bool    autoUpdate;                 
@@ -43,7 +43,7 @@ class userParameters
     int         getStepperPower()            {return stepperPower;}
     bool        getStealthchop()             {return stealthchop;}
     float       getInclineMultiplier()       {return inclineMultiplier;}
-    bool        getSimulatePower()           {return simulatePower;}
+    bool        getDoublePower()             {return doublePower;}
     bool        getSimulateHr()              {return simulateHr;}
     bool        getERGMode()                 {return ERGMode;}
     bool        getautoUpdate()              {return autoUpdate;}
@@ -64,7 +64,7 @@ class userParameters
     void    setStepperPower(int sp)             {stepperPower = sp;}
     void    setStealthChop(bool sc)             {stealthchop = sc;}
     void    setInclineMultiplier(float im)      {inclineMultiplier = im;}
-    void    setSimulatePower(bool sp)           {simulatePower = sp;}
+    void    setDoublePower(bool sp)             {doublePower = sp;}
     void    setSimulateHr(bool shr)             {simulateHr = shr;}
     void    setERGMode(bool erg)                {ERGMode = erg;}
     void    setAutoUpdate(bool atupd)           {autoUpdate = atupd;}

--- a/include/settings.h
+++ b/include/settings.h
@@ -10,7 +10,7 @@
 #define SETTINGS_H
 
 //Current program version info. Used for auto updates
-#define FIRMWARE_VERSION "0.1.1.11"
+#define FIRMWARE_VERSION "0.1.1.22"
 
 //Update firmware on boot?
 #define AUTO_FIRMWARE_UPDATE true

--- a/src/BLE_Client.cpp
+++ b/src/BLE_Client.cpp
@@ -472,7 +472,7 @@ void SpinBLEClient::scanProcess()
     pBLEScan->setInterval(550);
     pBLEScan->setWindow(500);
     pBLEScan->setActiveScan(true);
-    BLEScanResults foundDevices = pBLEScan->start(10, true);
+    BLEScanResults foundDevices = pBLEScan->start(10, false);
 
     // Load the scan into a Json String
     int count = foundDevices.getCount();

--- a/src/BLE_Client.cpp
+++ b/src/BLE_Client.cpp
@@ -162,7 +162,7 @@ static void notifyCallback(
             debugDirector("Disconnecting secondary PM");
             intentionalDisconnect = true;
             pBLERemoteCharacteristic->getRemoteService()->getClient()->disconnect();
-            NimBLEDevice::deleteClient(pBLERemoteCharacteristic->getRemoteService()->getClient()); //this was an old client, disconnect it.
+            //NimBLEDevice::deleteClient(pBLERemoteCharacteristic->getRemoteService()->getClient()); //this was an old client, disconnect it.
         }
     }
 }
@@ -272,6 +272,7 @@ bool SpinBLEClient::connectToServer()
                     connectedPM = true;
                     doConnectPM = false;
                     reconnectTries = MAX_RECONNECT_TRIES;
+                    lastConnectedPMID = pClient->getConnId();
                 }
 
                 if (pRemoteService->getUUID() == HEARTSERVICE_UUID)

--- a/src/BLE_Client.cpp
+++ b/src/BLE_Client.cpp
@@ -472,7 +472,7 @@ void SpinBLEClient::scanProcess()
     pBLEScan->setInterval(550);
     pBLEScan->setWindow(500);
     pBLEScan->setActiveScan(true);
-    BLEScanResults foundDevices = pBLEScan->start(10, false);
+    BLEScanResults foundDevices = pBLEScan->start(10, true);
 
     // Load the scan into a Json String
     int count = foundDevices.getCount();
@@ -500,6 +500,7 @@ void SpinBLEClient::scanProcess()
             }
         }
     }
+
     String output;
     serializeJson(devices, output);
     debugDirector("Bluetooth Client Found Devices: " + output);

--- a/src/BLE_Client.cpp
+++ b/src/BLE_Client.cpp
@@ -18,6 +18,8 @@ BLE Advertised Device found: Name: ASSIOMA17287L, Address: e8:fe:6e:91:9f:16, ap
 int reconnectTries = MAX_RECONNECT_TRIES;
 int scanRetries = MAX_SCAN_RETRIES;
 
+bool intentionalDisconnect = false;
+
 TaskHandle_t BLEClientTask;
 
 SpinBLEClient spinBLEClient;
@@ -26,7 +28,7 @@ void SpinBLEClient::start()
 {
     //Create the task for the BLE Client loop
     xTaskCreatePinnedToCore(
-        bleClientTask,       /* Task function. */
+        bleClientTask,   /* Task function. */
         "BLEClientTask", /* name of task. */
         3500,            /* Stack size of task */
         NULL,            /* parameter of the task */
@@ -50,14 +52,13 @@ void bleClientTask(void *pvParameters)
             {
             }
         }
-        if ((spinBLEClient.connectedPM) || (spinBLEClient.connectedHR))
+
+        if (spinBLEClient.doScan && (scanRetries > 0))
         {
-            if (spinBLEClient.doScan && (scanRetries > 0))
-            {
-                scanRetries--;
-                spinBLEClient.serverScan(true);
-            }
+            scanRetries--;
+            spinBLEClient.scanProcess();
         }
+
         vTaskDelay(BLE_CLIENT_DELAY / portTICK_PERIOD_MS); // Delay a second between loops.
                                                            //debugDirector("BLEclient High Water Mark: " + String(uxTaskGetStackHighWaterMark(BLEClientTask)));
     }
@@ -69,8 +70,6 @@ static void notifyCallback(
     size_t length,
     bool isNotify)
 {
-    if(pBLERemoteCharacteristic->getRemoteService()->getClient()->getConnId() == spinBLEClient.lastConnectedPMID) //disregarding other pm's that may still be connected
-    {
     for (int i = 0; i < length; i++)
     {
         debugDirector(String(pData[i], HEX) + " ", false);
@@ -86,76 +85,85 @@ static void notifyCallback(
 
     if (pBLERemoteCharacteristic->getUUID() == CYCLINGPOWERMEASUREMENT_UUID)
     {
-        //first calculate which fields are present. Power is always 2 & 3, cadence can move depending on the flags.
-        byte flags = pData[0];
-        int cPos = 4; //lowest position cadence could ever be
-        if (bitRead(flags, 0))
+        if (pBLERemoteCharacteristic->getRemoteService()->getClient()->getConnId() == spinBLEClient.lastConnectedPMID) //disregarding other pm's that may still be connected
         {
-            //pedal balance field present
-            cPos++;
-        }
-        if (bitRead(flags, 1))
-        {
-            //pedal power balance reference
-            //no field associated with this.
-        }
-        if (bitRead(flags, 2))
-        {
-            //accumulated torque field present
-            cPos++;
-        }
-        if (bitRead(flags, 3))
-        {
-            //accumulated torque field source
-            //no field associated with this.
-        }
-        if (bitRead(flags, 4))
-        {
-            //Wheel Revolution field PAIR Data present. 32-bits for wheel revs, 16 bits for wheel event time.
-            //Why is that so hard to find in the specs?
-            cPos += 6;
-        }
-        if (bitRead(flags, 5))
-        {
-            //Crank Revolution data present, lets process it.
-            spinBLEClient.crankRev[1] = spinBLEClient.crankRev[0];
-            spinBLEClient.crankRev[0] = bytes_to_int(pData[cPos + 1], pData[cPos]);
-            spinBLEClient.crankEventTime[1] = spinBLEClient.crankEventTime[0];
-            spinBLEClient.crankEventTime[0] = bytes_to_int(pData[cPos + 3], pData[cPos + 2]);
-            if ((spinBLEClient.crankRev[0] > spinBLEClient.crankRev[1]) && (spinBLEClient.crankEventTime[0] - spinBLEClient.crankEventTime[1] != 0))
+            //first calculate which fields are present. Power is always 2 & 3, cadence can move depending on the flags.
+            byte flags = pData[0];
+            int cPos = 4; //lowest position cadence could ever be
+            if (bitRead(flags, 0))
             {
-                int tCAD = (((abs(spinBLEClient.crankRev[0] - spinBLEClient.crankRev[1]) * 1024) / abs(spinBLEClient.crankEventTime[0] - spinBLEClient.crankEventTime[1])) * 60);
-                if (tCAD > 1)
+                //pedal balance field present
+                cPos++;
+            }
+            if (bitRead(flags, 1))
+            {
+                //pedal power balance reference
+                //no field associated with this.
+            }
+            if (bitRead(flags, 2))
+            {
+                //accumulated torque field present
+                cPos++;
+            }
+            if (bitRead(flags, 3))
+            {
+                //accumulated torque field source
+                //no field associated with this.
+            }
+            if (bitRead(flags, 4))
+            {
+                //Wheel Revolution field PAIR Data present. 32-bits for wheel revs, 16 bits for wheel event time.
+                //Why is that so hard to find in the specs?
+                cPos += 6;
+            }
+            if (bitRead(flags, 5))
+            {
+                //Crank Revolution data present, lets process it.
+                spinBLEClient.crankRev[1] = spinBLEClient.crankRev[0];
+                spinBLEClient.crankRev[0] = bytes_to_int(pData[cPos + 1], pData[cPos]);
+                spinBLEClient.crankEventTime[1] = spinBLEClient.crankEventTime[0];
+                spinBLEClient.crankEventTime[0] = bytes_to_int(pData[cPos + 3], pData[cPos + 2]);
+                if ((spinBLEClient.crankRev[0] > spinBLEClient.crankRev[1]) && (spinBLEClient.crankEventTime[0] - spinBLEClient.crankEventTime[1] != 0))
                 {
-                    userConfig.setSimulatedCad(tCAD);
-                    spinBLEClient.noReadingIn = 0;
+                    int tCAD = (((abs(spinBLEClient.crankRev[0] - spinBLEClient.crankRev[1]) * 1024) / abs(spinBLEClient.crankEventTime[0] - spinBLEClient.crankEventTime[1])) * 60);
+                    if (tCAD > 1)
+                    {
+                        userConfig.setSimulatedCad(tCAD);
+                        spinBLEClient.noReadingIn = 0;
+                    }
+                    else
+                    {
+                        spinBLEClient.noReadingIn++;
+                    }
                 }
-                else
+                else //the crank rev probably didn't update
                 {
+                    if (spinBLEClient.noReadingIn > 2) //Require three consecutive readings before setting 0 cadence
+                    {
+                        userConfig.setSimulatedCad(0);
+                    }
                     spinBLEClient.noReadingIn++;
                 }
-            }
-            else //the crank rev probably didn't update
-            {
-                if (spinBLEClient.noReadingIn > 2) //Require three consecutive readings before setting 0 cadence
-                {
-                    userConfig.setSimulatedCad(0);
-                }
-                spinBLEClient.noReadingIn++;
+
+                debugDirector(" CAD: " + String(userConfig.getSimulatedCad()), false);
+                debugDirector("");
             }
 
-            debugDirector(" CAD: " + String(userConfig.getSimulatedCad()), false);
-            debugDirector("");
+            //Watts are so much easier......
+            userConfig.setSimulatedWatts(bytes_to_u16(pData[3], pData[2]));
+            if (userConfig.getDoublePower())
+            {
+                userConfig.setSimulatedWatts(userConfig.getSimulatedWatts() * 2);
+            }
         }
 
-        //Watts are so much easier......
-        userConfig.setSimulatedWatts(bytes_to_u16(pData[3], pData[2]));
-    }
-    }
-    else
-    {
-        debugDirector("Disconnecting secondary PM");
-        NimBLEDevice::deleteClient(pBLERemoteCharacteristic->getRemoteService()->getClient()); //this was an old client, disconnect it. 
+        else
+        {
+            debugDirector("Disconnecting secondary PM");
+            intentionalDisconnect = true;
+            pBLERemoteCharacteristic->getRemoteService()->getClient()->disconnect();
+            NimBLEDevice::deleteClient(pBLERemoteCharacteristic->getRemoteService()->getClient()); //this was an old client, disconnect it.
+        }
     }
 }
 
@@ -380,6 +388,11 @@ void SpinBLEClient::MyClientCallback::onConnect(BLEClient *pclient)
 }
 void SpinBLEClient::MyClientCallback::onDisconnect(BLEClient *pclient)
 {
+    if (intentionalDisconnect)
+    {
+        intentionalDisconnect = false;
+        return;
+    }
     if ((pclient->getService(HEARTSERVICE_UUID)) && (!(pclient->isConnected())))
     {
         debugDirector("Detected HR Disconnect. Trying rapid reconnect");
@@ -445,7 +458,7 @@ void SpinBLEClient::MyAdvertisedDeviceCallback::onResult(BLEAdvertisedDevice *ad
     }
 }
 
-void SpinBLEClient::serverScan(bool connectRequest)
+void SpinBLEClient::scanProcess()
 {
     //doConnect = connectRequest;
     debugDirector("Scanning for BLE servers and putting them into a list...");
@@ -490,4 +503,13 @@ void SpinBLEClient::serverScan(bool connectRequest)
     serializeJson(devices, output);
     debugDirector("Bluetooth Client Found Devices: " + output);
     userConfig.setFoundDevices(output);
+}
+
+void SpinBLEClient::serverScan(bool connectRequest)
+{
+    if (connectRequest)
+    {
+        scanRetries = MAX_SCAN_RETRIES;
+    }
+    spinBLEClient.doScan = true;
 }

--- a/src/BLE_Client.cpp
+++ b/src/BLE_Client.cpp
@@ -69,7 +69,8 @@ static void notifyCallback(
     size_t length,
     bool isNotify)
 {
-
+    if(pBLERemoteCharacteristic->getRemoteService()->getClient()->getConnId() == spinBLEClient.lastConnectedPMID) //disregarding other pm's that may still be connected
+    {
     for (int i = 0; i < length; i++)
     {
         debugDirector(String(pData[i], HEX) + " ", false);
@@ -149,6 +150,12 @@ static void notifyCallback(
 
         //Watts are so much easier......
         userConfig.setSimulatedWatts(bytes_to_u16(pData[3], pData[2]));
+    }
+    }
+    else
+    {
+        debugDirector("Disconnecting secondary PM");
+        NimBLEDevice::deleteClient(pBLERemoteCharacteristic->getRemoteService()->getClient()); //this was an old client, disconnect it. 
     }
 }
 
@@ -347,6 +354,7 @@ bool SpinBLEClient::connectToServer()
             connectedPM = true;
             doConnectPM = false;
             debugDirector("Sucessful PM");
+            lastConnectedPMID = pClient->getConnId();
         }
 
         if (pRemoteService->getUUID() == HEARTSERVICE_UUID)

--- a/src/HTTP_Server_Basic.cpp
+++ b/src/HTTP_Server_Basic.cpp
@@ -242,7 +242,7 @@ void startHttpServer()
 
   server.on("/BLEScan", []() {
     debugDirector("Scanning from web request");
-    String response = "<!DOCTYPE html><html><body>Scanning for BLE Devices. Please wait 10 seconds.</body><script> setTimeout(\"location.href = 'http://" + String(userConfig.getDeviceName()) + ".local/bluetoothscanner.html';\",10000);</script></html>";
+    String response = "<!DOCTYPE html><html><body>Scanning for BLE Devices. Please wait 15 seconds.</body><script> setTimeout(\"location.href = 'http://" + String(userConfig.getDeviceName()) + ".local/bluetoothscanner.html';\",15000);</script></html>";
     spinBLEClient.serverScan(true);
     //spinBLEClient.serverScan(true);
     server.send(200, "text/html", response);

--- a/src/HTTP_Server_Basic.cpp
+++ b/src/HTTP_Server_Basic.cpp
@@ -184,6 +184,14 @@ void startHttpServer()
       {
         userConfig.setConnectedHeartMonitor("any");
       }
+      if (!server.arg("doublePower").isEmpty())
+      {
+        userConfig.setDoublePower(true);
+      }
+      else
+      {
+        userConfig.setDoublePower(false);
+      }
     }
 
     if (!server.arg("session1HR").isEmpty()) //Needs checking for unrealistic numbers. 
@@ -214,6 +222,7 @@ void startHttpServer()
   
 
     String response = "<!DOCTYPE html><html><body><h2>";
+
     if (wasBTUpdate) //Special BT update response
     {
       response += "Selections Saved!</h2></body><script> setTimeout(\"location.href = 'http://" + String(userConfig.getDeviceName()) + ".local/bluetoothscanner.html';\",1000);</script></html>";
@@ -231,29 +240,11 @@ void startHttpServer()
     userPWC.printFile();
   });
 
-  server.on("/BLEServers", []() {
-    debugDirector("Sending BLE device list to HTTP Client");
-    String tString = "";
-    const char *bracket = "{";
-    if (!(String(userConfig.getFoundDevices()).startsWith(bracket)))
-    {
-      tString += "{";
-    }
-    else
-    {
-      tString += String(userConfig.getFoundDevices());
-      tString.remove(tString.length() - 1, 1);
-      tString += ",";
-    }
-
-    tString += String("\"connectedHeartMonitor\":\"") + userConfig.getconnectedHeartMonitor() + "\",\"connectedPowerMeter\":\"" + userConfig.getconnectedPowerMeter() + "\"}";
-    server.send(200, "text/plain", tString);
-  });
-
   server.on("/BLEScan", []() {
-    debugDirector("Scanning for BLE Devices");
-    String response = "<!DOCTYPE html><html><body>Scanning for BLE Devices. Please wait 5 seconds.</body><script> setTimeout(\"location.href = 'http://" + String(userConfig.getDeviceName()) + ".local/bluetoothscanner.html';\",5000);</script></html>";
+    debugDirector("Scanning from web request");
+    String response = "<!DOCTYPE html><html><body>Scanning for BLE Devices. Please wait 10 seconds.</body><script> setTimeout(\"location.href = 'http://" + String(userConfig.getDeviceName()) + ".local/bluetoothscanner.html';\",10000);</script></html>";
     spinBLEClient.serverScan(true);
+    //spinBLEClient.serverScan(true);
     server.send(200, "text/html", response);
   });
 
@@ -302,13 +293,13 @@ void startHttpServer()
     String value = server.arg("value");
     if (value == "enable")
     {
-      userConfig.setSimulatePower(true);
+      userConfig.setDoublePower(true);
       server.send(200, "text/plain", "OK");
       debugDirector("Watt Simulator turned on");
     }
     else if (value == "disable")
     {
-      userConfig.setSimulatePower(false);
+      userConfig.setDoublePower(false);
       server.send(200, "text/plain", "OK");
       debugDirector("Watt Simulator turned off");
     }

--- a/src/SmartSpin_parameters.cpp
+++ b/src/SmartSpin_parameters.cpp
@@ -24,7 +24,7 @@ void userParameters::setDefaults() //Move these to set the values as #define in 
   stepperPower          = STEPPER_POWER;
   stealthchop           = STEALTHCHOP;
   inclineMultiplier     = 2.0;
-  simulatePower         = false;
+  doublePower           = false;
   simulateHr            = true;
   ERGMode               = false;
   autoUpdate            = AUTO_FIRMWARE_UPDATE;
@@ -55,7 +55,7 @@ String userParameters::returnJSON()
   doc["stepperPower"]           = stepperPower;
   doc["stealthchop"]            = stealthchop;
   doc["inclineMultiplier"]      = inclineMultiplier;
-  doc["simulatePower"]          = simulatePower;
+  doc["doublePower"]            = doublePower;
   doc["simulateHr"]             = simulateHr;
   doc["ERGMode"]                = ERGMode;
   doc["autoUpdate"]             = autoUpdate;
@@ -101,7 +101,7 @@ void userParameters::saveToSPIFFS()
   doc["stepperPower"]           = stepperPower;
   doc["stealthchop"]            = stealthchop;
   doc["inclineMultiplier"]      = inclineMultiplier;
-  doc["simulatePower"]          = simulatePower;
+  doc["doublePower"]            = doublePower;
   doc["simulateHr"]             = simulateHr;
   doc["ERGMode"]                = ERGMode;
   doc["autoUpdate"]             = autoUpdate;
@@ -159,7 +159,7 @@ void userParameters::loadFromSPIFFS()
   setStepperPower         (doc["stepperPower"]);
   setStealthChop          (doc["stealthchop"]);
   setInclineMultiplier    (doc["inclineMultiplier"]);
-  setSimulatePower        (doc["simulatePower"]);
+  setDoublePower          (doc["doublePower"]);
   setSimulateHr           (doc["simulateHr"]);
   setERGMode              (doc["ERGMode"]);
   setAutoUpdate           (doc["autoUpdate"]);


### PR DESCRIPTION
Lots of changes:

Powermeter will now switch to only the most recently connected.
Double power option in the bluetooth scanner.
Bluetooth scanning now happens via a flag set in the client task because spawning it in the HTTP task was causing crashes. 
Backend of the bluetooth scanning page revamped. 
Removed dedicated server callback for the bluetooth scanner via HTML. 

 