### PR TITLE
Set hostname for dns

### DIFF
--- a/data/settings.html
+++ b/data/settings.html
@@ -43,7 +43,7 @@
             </tr>
             <tr>
               <td>
-                <p class="tooltip">MDNS Name<span class="tooltiptext">DNS Name the device will use on the
+                <p class="tooltip">Hostname<span class="tooltiptext">DNS Name the device will use on the
                     network.</span></p>
               </td>
               <td><input type="text" id="deviceName" name="deviceName" value="loading" />

--- a/src/HTTP_Server_Basic.cpp
+++ b/src/HTTP_Server_Basic.cpp
@@ -55,7 +55,11 @@ void startWifi()
   {
     WiFi.mode(WIFI_STA);
     WiFi.setTxPower(WIFI_POWER_19_5dBm);
+    // Setting the hostname for DNS requires this line before calling "Wifi.begin(...)"
+    // See: https://github.com/espressif/arduino-esp32/issues/2537#issuecomment-590029109
+    WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
     WiFi.begin(userConfig.getSsid(), userConfig.getPassword());
+    WiFi.setHostname(userConfig.getDeviceName());
   }
 
   while (WiFi.status() != WL_CONNECTED)


### PR DESCRIPTION
https://github.com/espressif/arduino-esp32/issues/2537#issuecomment-590029109 gave a workaround so that the hostname for DNS could be correctly sent.  This will allow accessing the the website by going to `http://smartspin2k/"

![image](https://user-images.githubusercontent.com/1904898/110293071-f3676080-7fa2-11eb-8fe7-92d08b8ffd95.png)
