### PR TITLE
Broadcast locally shifted resistance changes over FTMS status characteristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add ability to broadcast locally triggered resistance changes via FTMS status characteristic.
 - Added additional FTMS characteristics and some refactoring of shared variables
 - Added GZipped jQuery to fix non WAN connected manual updates.
 - Pin arduino-esp32 package to version 1.0.6 to fix build issue

--- a/include/BLE_Common.h
+++ b/include/BLE_Common.h
@@ -40,6 +40,7 @@ void updateIndoorBikeDataChar();
 void updateCyclingPowerMesurementChar();
 void calculateInstPwrFromHR();
 void updateHeartRateMeasurementChar();
+void updateFTMStatusCharWithResistance();
 int connectedClientCount();
 void controlPointIndicate();
 

--- a/include/Main.h
+++ b/include/Main.h
@@ -18,6 +18,7 @@ void IRAM_ATTR moveStepper(void* pvParameters);
 void IRAM_ATTR shiftUp();
 void IRAM_ATTR shiftDown();
 void debugDirector(String, bool = true, bool = false);
+void broadcastChangesIfRequired();
 void resetIfShiftersHeld();
 void scanIfShiftersHeld();
 void setupTMCStepperDriver();

--- a/src/BLE_Server.cpp
+++ b/src/BLE_Server.cpp
@@ -306,8 +306,16 @@ void updateHeartRateMeasurementChar() {
   debugDirector(String(logBuf), true);
 }
 
-// Creating Server Connection Callbacks
 
+void updateFTMStatusCharWithResistance() {
+  uint8_t resistanceStatus[2] = {0x07, 0x00}; // 0x07 - resistance has changed
+  resistanceStatus[1] = userConfig.getShifterPosition() / userConfig.getShiftStep();
+  fitnessMachineStatusCharacteristic->setValue(resistanceStatus, 2);
+  fitnessMachineStatusCharacteristic->notify();
+}
+
+
+// Creating Server Connection Callbacks
 void MyServerCallbacks::onConnect(BLEServer *pServer, ble_gap_conn_desc *desc) {
   debugDirector("Bluetooth Remote Client Connected: " + String(NimBLEAddress(desc->peer_ota_addr).toString().c_str()) +
                 " Connected Clients: " + String(pServer->getConnectedCount()));


### PR DESCRIPTION
Updated to broadcast any hard-triggered local changes to resistance over the FTMS status characteristic.

This means that, if you use the local shifter controls, any remotely connected BLE central devices will receive a notification that the resistance level has changed.

This is achieved via adding an additional flag in Main.cpp `resistanceIsDirty` that is set by the IRAM methods `shiftUp` or `shiftDown` to indicate when the resistance has been changed.

An additional method called by the main run loop, `broadcastChangesIfRequired()` monitors this flag. If the flag becomes set, it is reset and the method `BLE_Server::updateFTMStatusCharWithResistance()` is called to broadcast the new resistance to any connected centrals.