### PR TITLE
Automatic Spiffs to LittleFS upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - updated CA for OTA updates
  - Converted filesystem from SPIFFS to LittleFS
  - Added functions for automatic settings conversion from SPIFFS
+ - Fixed endianness for ftmsPowerRange and ftmsPowerRange.
 
 
 ### Hardware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - updated CA for OTA updates
  - Converted filesystem from SPIFFS to LittleFS
+ - Added functions for automatic settings conversion from SPIFFS
 
 
 ### Hardware

--- a/include/LittleFS_Upgrade.h
+++ b/include/LittleFS_Upgrade.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <LittleFS.h>
+//#include <LittleFS.h>
 #include <SPIFFS.h>
 #include <Arduino.h>
 
@@ -21,4 +21,5 @@ class FSUpgrader {
 
  public:
   void upgradeFS();
+
 };

--- a/include/LittleFS_Upgrade.h
+++ b/include/LittleFS_Upgrade.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020  Anthony Doud & Joel Baranick
+ * All rights reserved
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#pragma once
+
+#include <LittleFS.h>
+#include <SPIFFS.h>
+#include <Arduino.h>
+
+#define FS_UPGRADER_LOG_TAG "FS_Upgrader"
+
+class FSUpgrader {
+ private:
+  bool spiffsExists = false;
+  File file;
+  void loadFromSPIFFS();
+
+ public:
+  void upgradeFS();
+};

--- a/include/Main.h
+++ b/include/Main.h
@@ -11,6 +11,7 @@
 #include "HTTP_Server_Basic.h"
 #include "SmartSpin_parameters.h"
 #include "BLE_Common.h"
+#include "LittleFS_Upgrade.h"
 
 #define MAIN_LOG_TAG "Main"
 

--- a/src/BLE_Server.cpp
+++ b/src/BLE_Server.cpp
@@ -79,8 +79,8 @@ struct FitnessMachineFeature ftmsFeature = {
 
 uint8_t ftmsIndoorBikeData[14] = {0x44, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};  // 00000000100001010100 ISpeed, ICAD,
                                                                                                             // TDistance, IPower, ETime
-uint8_t ftmsResistanceLevelRange[6]      = {0x00, 0x01, 0x25, 0x00, 0x01, 0x00};                            // 1:37 increment 1
-uint8_t ftmsPowerRange[6]                = {0x00, 0x01, 0xA0, 0x0F, 0x01, 0x00};                            // 1:4000 watts increment 1
+uint8_t ftmsResistanceLevelRange[6]      = {0x01, 0x00, 0x25, 0x00, 0x01, 0x00};                            // 1:37 increment 1
+uint8_t ftmsPowerRange[6]                = {0x01, 0x00, 0xA0, 0x0F, 0x01, 0x00};                            // 1:4000 watts increment 1
 uint8_t ftmsInclinationRange[6]          = {0x38, 0xff, 0xc8, 0x00, 0x01, 0x00};                            // -20.0:20.0 increment .1
 uint8_t ftmsTrainingStatus[2]            = {0x08, 0x00};
 uint8_t ss2kCustomCharacteristicValue[3] = {0x00, 0x00, 0x00};
@@ -432,7 +432,7 @@ void processFTMSWrite() {
                                    rtConfig.getSimulatedWatts().value, rtConfig.getTargetIncline() / 100);
 
           ftmsStatus            = {FitnessMachineStatus::TargetPowerChanged, (uint8_t)rxValue[1], (uint8_t)rxValue[2]};
-          ftmsTrainingStatus[1] = FitnessMachineTrainingStatus::WattControl;  // 0x0C;
+          ftmsTrainingStatus[1] = FitnessMachineTrainingStatus::Other;  // 0x0C;
           fitnessMachineTrainingStatus->setValue(ftmsTrainingStatus, 2);
         } else {
           returnValue[2] = FitnessMachineControlPointResultCode::OpCodeNotSupported;  // 0x02; no power meter connected, so no ERG

--- a/src/LittleFS_Upgrade.cpp
+++ b/src/LittleFS_Upgrade.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020  Anthony Doud & Joel Baranick
+ * All rights reserved
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "LittleFS_Upgrade.h"
+#include "Main.h"
+#include <Arduino.h>
+#include <LittleFS.h>
+#include <SPIFFS.h>
+
+void FSUpgrader::UpgradeFS() {
+  if (!SPIFFS.begin()) {
+    SS2K_LOG(FS_UPGRADER_LOG_TAG, "SPIFFS Not Found - Could not upgrade FS");
+    SPIFFS.end();
+    LittleFS.begin();
+    LittleFS.format();
+    LittleFS.end();
+    return;
+  };
+  file = SPIFFS.open(configFILENAME, FILE_WRITE);
+}
+
+// Loads the JSON configuration from a file into a userParameters Object
+void FSUpgrader::loadFromSPIFFS() {
+  userConfig.setDefaults();
+  // Open file for reading
+  SS2K_LOG(CONFIG_LOG_TAG, "Reading File: %s", configFILENAME);
+  File file = LittleFS.open(configFILENAME);
+
+  // load defaults if filename doesn't exist
+  if (!file) {
+    SS2K_LOG(CONFIG_LOG_TAG, "Couldn't find configuration file. using defaults");
+    return;
+  }
+  // Allocate a temporary JsonDocument
+  // Don't forget to change the capacity to match your requirements.
+  // Use arduinojson.org/v6/assistant to compute the capacity.
+  StaticJsonDocument<USERCONFIG_JSON_SIZE> doc;
+
+  // Deserialize the JSON document
+  DeserializationError error = deserializeJson(doc, file);
+  if (error) {
+    SS2K_LOG(CONFIG_LOG_TAG, "Failed to read file, using defaults");
+    return;
+  }
+
+  // Copy values from the JsonDocument to the Config
+  setFirmwareUpdateURL(doc["firmwareUpdateURL"]);
+  setDeviceName(doc["deviceName"]);
+  setShiftStep(doc["shiftStep"]);
+  setStepperPower(doc["stepperPower"]);
+  setStealthChop(doc["stealthchop"]);
+  setInclineMultiplier(doc["inclineMultiplier"]);
+  setAutoUpdate(doc["autoUpdate"]);
+  setSsid(doc["ssid"]);
+  setPassword(doc["password"]);
+  setConnectedPowerMeter(doc["connectedPowerMeter"]);
+  setConnectedHeartMonitor(doc["connectedHeartMonitor"]);
+  setFoundDevices(doc["foundDevices"]);
+  if (doc["ERGSensitivity"]) {  // If statements to upgrade old versions of config.txt that didn't include these
+    setERGSensitivity(doc["ERGSensitivity"]);
+  }
+  if (doc["maxWatts"]) {
+    setMaxWatts(doc["maxWatts"]);
+  }
+  if (!doc["stepperDir"].isNull()) {
+    setStepperDir(doc["stepperDir"]);
+  }
+  if (!doc["shifterDir"].isNull()) {
+    setShifterDir(doc["shifterDir"]);
+  }
+  if (!doc["udpLogEnabled"].isNull()) {
+    setUdpLogEnabled(doc["udpLogEnabled"]);
+  }
+  if (doc["powerCorrectionFactor"]) {
+    setPowerCorrectionFactor(doc["powerCorrectionFactor"]);
+    if ((getPowerCorrectionFactor() < MIN_PCF) || (getPowerCorrectionFactor() > MAX_PCF)) {
+      setPowerCorrectionFactor(1);
+    }
+  }
+
+  SS2K_LOG(CONFIG_LOG_TAG, "Config File Loaded: %s", configFILENAME);
+  file.close();
+}
+
+// Prints the content of a file to the Serial
+void userParameters::printFile() {
+  // Open file for reading
+  SS2K_LOG(CONFIG_LOG_TAG, "Contents of file: %s", configFILENAME);
+  File file = LittleFS.open(configFILENAME);
+  if (!file) {
+    SS2K_LOG(CONFIG_LOG_TAG, "Failed to read file");
+    return;
+  }
+
+  // Close the file
+  file.close();
+}

--- a/src/LittleFS_Upgrade.cpp
+++ b/src/LittleFS_Upgrade.cpp
@@ -33,6 +33,7 @@ void FSUpgrader::upgradeFS() {
   }
   LittleFS.format();
   userConfig.saveToLittleFS();
+  userPWC.saveToLittleFS();
 }
 
 // Loads the JSON configuration from a file into a userParameters Object
@@ -96,4 +97,35 @@ void FSUpgrader::loadFromSPIFFS() {
 
   SS2K_LOG(FS_UPGRADER_LOG_TAG, "Config File Loaded: %s", configFILENAME);
   this->file.close();
+
+  // Loading USER PWC
+  SS2K_LOG(FS_UPGRADER_LOG_TAG, "Reading File: %s", userPWCFILENAME);
+  File file = SPIFFS.open(userPWCFILENAME);
+
+  // load defaults if filename doesn't exist
+  if (!file) {
+    SS2K_LOG(FS_UPGRADER_LOG_TAG, "Couldn't find configuration file. Loading Defaults");
+    userPWC.setDefaults();
+    return;
+  }
+
+  doc.clear();
+
+  // Deserialize the JSON document
+  DeserializationError errorTwo = deserializeJson(doc, file);
+  if (errorTwo) {
+    SS2K_LOG(FS_UPGRADER_LOG_TAG, "Failed to read file, using default configuration");
+    userPWC.setDefaults();
+    return;
+  }
+
+  // Copy values from the JsonDocument to the Config
+  userPWC.session1HR  = doc["session1HR"];
+  userPWC.session1Pwr = doc["session1Pwr"];
+  userPWC.session2HR  = doc["session2HR"];
+  userPWC.session2Pwr = doc["session2Pwr"];
+  userPWC.hr2Pwr      = doc["hr2Pwr"];
+
+  SS2K_LOG(FS_UPGRADER_LOG_TAG, "Config File Loaded: %s", userPWCFILENAME);
+  file.close();
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -75,7 +75,6 @@ void setup() {
     SS2K_LOG(MAIN_LOG_TAG, "An Error has occurred while mounting LittleFS.");
     // BEGIN FS UPGRADE SPECIFIC//
     upgrade.upgradeFS();
-    //LittleFS.begin();
     // END FS UPGRADE SPECIFIC//
   }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -35,6 +35,10 @@ physicalWorkingCapacity userPWC;
 UdpAppender udpAppender;
 WebSocketAppender webSocketAppender;
 
+///////////// FS Upgrader //////////////
+
+//^Remove this after a few OTA updates//
+
 ///////////// BEGIN SETUP /////////////
 #ifndef UNIT_TEST
 
@@ -66,10 +70,13 @@ void setup() {
 
   // Initialize LittleFS
   SS2K_LOG(MAIN_LOG_TAG, "Mounting Filesystem");
-  if (!LittleFS.begin(true)) {
-    SS2K_LOG(MAIN_LOG_TAG, "An Error has occurred while mounting LittleFS");
-    // TODO reset flash here
-    return;
+  if (!LittleFS.begin(false)) {
+    FSUpgrader upgrade;
+    SS2K_LOG(MAIN_LOG_TAG, "An Error has occurred while mounting LittleFS.");
+    // BEGIN FS UPGRADE SPECIFIC//
+    upgrade.upgradeFS();
+    //LittleFS.begin();
+    // END FS UPGRADE SPECIFIC//
   }
 
   // Load Config
@@ -235,7 +242,7 @@ void SS2K::moveStepper(void *pvParameters) {
           ss2k.targetPosition = rtConfig.getTargetIncline();
         } else {
           // Simulation Mode
-          ss2k.targetPosition   = rtConfig.getShifterPosition() * userConfig.getShiftStep();
+          ss2k.targetPosition = rtConfig.getShifterPosition() * userConfig.getShiftStep();
           ss2k.targetPosition += rtConfig.getTargetIncline() * userConfig.getInclineMultiplier();
         }
       }

--- a/src/SmartSpin_parameters.cpp
+++ b/src/SmartSpin_parameters.cpp
@@ -152,7 +152,7 @@ void userParameters::loadFromLittleFS() {
 
   // load defaults if filename doesn't exist
   if (!file) {
-    SS2K_LOG(CONFIG_LOG_TAG, "Couldn't find configuration file. using defaults");
+    SS2K_LOG(CONFIG_LOG_TAG, "Couldn't find configuration file.");
     return;
   }
   // Allocate a temporary JsonDocument
@@ -163,7 +163,7 @@ void userParameters::loadFromLittleFS() {
   // Deserialize the JSON document
   DeserializationError error = deserializeJson(doc, file);
   if (error) {
-    SS2K_LOG(CONFIG_LOG_TAG, "Failed to read file, using defaults");
+    SS2K_LOG(CONFIG_LOG_TAG, "Failed to deserialize. Using defaults");
     return;
   }
 


### PR DESCRIPTION
This should now preserve settings and download the .html files if it detects an (old)  SPIFFS partition on boot. Minimal testing - I'd appreciate it if you guys give it a try. 

1. Install an old binary that uses SPIFFS.
2. Change some settings.
3. Install binary from this branch. 
4. Check to see if the settings successfully migrated. 
