### PR TITLE
Added THROTTLE_TEMP to settings.h. Increased temp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added StreamFit
 - Added developer tools html.
 - Added automatic board revision detection. 
+- Added THROTTLE_TEMP to settings.h. The internal ESP32 temperature at which to reduce driver current. 
 
 ### Changed
 - Fixed a few compile issues for case sensitive operating systems.
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BLE scan page now shows previous scan results.
 - BLE scan page duplicates bug fixed. 
 - BLE scan page dropdowns default to devices found during scan. 
+- Increased THROTTLE_TEMP from 72c to 85c. 
 
 ### Hardware
 - Ultra Short Direct Mount case for use on bikes with limited space between knob and head tube

--- a/include/settings.h
+++ b/include/settings.h
@@ -227,6 +227,9 @@
 // Number of similar power samples to take before writing to the Power Table
 #define POWER_SAMPLES 5
 
+// Temperature of the ESP32 at which to start reducing the power output of the stepper motor driver.
+#define THROTTLE_TEMP 85
+
 // Uncomment to enable sending Telegram debug messages back to the chat
 // specified in telegram_token.h
 // #define USE_TELEGRAM

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -407,10 +407,10 @@ void SS2K::updateStealthchop() {
 // Checks the driver temperature and throttles power if above threshold.
 void SS2K::checkDriverTemperature() {
   static bool overTemp = false;
-  if (static_cast<int>(temperatureRead()) > 72) {  // Start throttling driver power at 72C on the ESP32
-    uint8_t throttledPower = (72 - static_cast<int>(temperatureRead())) + DRIVER_MAX_PWR_SCALER;
+  if (static_cast<int>(temperatureRead()) > THROTTLE_TEMP) {  // Start throttling driver power at 72C on the ESP32
+    uint8_t throttledPower = (THROTTLE_TEMP - static_cast<int>(temperatureRead())) + DRIVER_MAX_PWR_SCALER;
     driver.irun(throttledPower);
-    SS2K_LOGW(MAIN_LOG_TAG, "Over temp! Driver is throttling down! ESP32 @ %f C", temperatureRead());
+    SS2K_LOG(MAIN_LOG_TAG, "Over temp! Driver is throttling down! ESP32 @ %f C", temperatureRead());
     overTemp = true;
   } else if ((driver.cs_actual() < DRIVER_MAX_PWR_SCALER) && !driver.stst()) {
     if (overTemp) {


### PR DESCRIPTION
Added THROTTLE_TEMP to settings.h. The internal ESP32 temperature at which to reduce driver current.

Increased the throttling temp from 72c to 85c 