### PR TITLE
Amend always option to git describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated wiki banner.
 
 ### Changed
+- Amend always option to git describe.
 - Updated communications overview picture.
 - Updated kit purchasing links. 
 - MIN_ERG_CADENCE created and changed from 20 to 30.

--- a/git_tag_macro.py
+++ b/git_tag_macro.py
@@ -17,7 +17,7 @@ branch = (
 #    )
 #else:
 tag = (
-    subprocess.check_output(["git", "describe", "--tags"])
+    subprocess.check_output(["git", "describe", "--tags", "--always"])
     .strip()
     .decode("utf-8")
     )


### PR DESCRIPTION
git_tag_macro.py throws an error "fatal: No names found, cannot describe anything." during PlatformIO initial setup on a new fork.  Looking online, the fix is to add --always to the git describe command.