### PR TITLE
Fixes not shifting after powertable has been deleted (without Cadence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
+### Hardware
+
+
+## [24.12.7]
+
+### Added
+
+### Changed
 - Fixes homing not being removed after powertable reset.
 - Shifting will always abort homing, even if homing hasn't been preformed yet. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fixes homing not being removed after powertable reset.
+- Shifting will always abort homing, even if homing hasn't been preformed yet. 
 
 ### Hardware
 

--- a/src/ERG_Mode.cpp
+++ b/src/ERG_Mode.cpp
@@ -69,9 +69,11 @@ void PowerTable::runERG() {
     }
 
     if (ss2k->resetPowerTableFlag) {
+      LittleFS.remove(POWER_TABLE_FILENAME);
       powerTable->reset();
       userConfig->setHMin(INT32_MIN);
       userConfig->setHMax(INT32_MIN);
+      spinBLEServer.spinDownFlag = 0;
       rtConfig->setHomed(false);
       userConfig->saveToLittleFS();
     }
@@ -873,7 +875,7 @@ bool PowerTable::_manageSaveState() {
 
     // If both current and saved tables were created with homing, we can skip position reliability checks
     bool canSkipReliabilityChecks = savedHomed && rtConfig->getHomed();
-    
+
     if (!canSkipReliabilityChecks) {
       // Initialize a counter for reliable positions
       int reliablePositions = 0;
@@ -914,7 +916,7 @@ bool PowerTable::_manageSaveState() {
     file.read((uint8_t*)&version, sizeof(version));
     file.read((uint8_t*)&savedQuality, sizeof(savedQuality));
     file.read((uint8_t*)&savedHomed, sizeof(savedHomed));
-    
+
     float averageOffset = 0;
     if (!canSkipReliabilityChecks) {
       std::vector<float> offsetDifferences;
@@ -966,7 +968,7 @@ bool PowerTable::_manageSaveState() {
       }
       SS2K_LOG(POWERTABLE_LOG_TAG, "Power Table loaded with an offset of %d.", averageOffset);
     }
-    
+
     // set the flag so it isn't loaded again this session.
     this->_hasBeenLoadedThisSession = true;
   }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -500,6 +500,7 @@ void IRAM_ATTR SS2K::shiftUp() {  // Handle the shift up interrupt IRAM_ATTR is 
   if (ss2k->deBounce()) {
     if (!digitalRead(currentBoard.shiftUpPin)) {  // double checking to make sure the interrupt wasn't triggered by emf
       rtConfig->setShifterPosition(rtConfig->getShifterPosition() - 1 + userConfig->getShifterDir() * 2);
+      spinBLEServer.spinDownFlag = 0;
     } else {
       ss2k->lastDebounceTime = 0;
     }  // Probably Triggered by EMF, reset the debounce
@@ -510,6 +511,7 @@ void IRAM_ATTR SS2K::shiftDown() {  // Handle the shift down interrupt
   if (ss2k->deBounce()) {
     if (!digitalRead(currentBoard.shiftDownPin)) {  // double checking to make sure the interrupt wasn't triggered by emf
       rtConfig->setShifterPosition(rtConfig->getShifterPosition() + 1 - userConfig->getShifterDir() * 2);
+      spinBLEServer.spinDownFlag = 0;
     } else {
       ss2k->lastDebounceTime = 0;
     }  // Probably Triggered by EMF, reset the debounce

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -500,6 +500,7 @@ void IRAM_ATTR SS2K::shiftUp() {  // Handle the shift up interrupt IRAM_ATTR is 
   if (ss2k->deBounce()) {
     if (!digitalRead(currentBoard.shiftUpPin)) {  // double checking to make sure the interrupt wasn't triggered by emf
       rtConfig->setShifterPosition(rtConfig->getShifterPosition() - 1 + userConfig->getShifterDir() * 2);
+      // Stop homing initiation
       spinBLEServer.spinDownFlag = 0;
     } else {
       ss2k->lastDebounceTime = 0;
@@ -511,6 +512,7 @@ void IRAM_ATTR SS2K::shiftDown() {  // Handle the shift down interrupt
   if (ss2k->deBounce()) {
     if (!digitalRead(currentBoard.shiftDownPin)) {  // double checking to make sure the interrupt wasn't triggered by emf
       rtConfig->setShifterPosition(rtConfig->getShifterPosition() + 1 - userConfig->getShifterDir() * 2);
+      // Stop homing initiation
       spinBLEServer.spinDownFlag = 0;
     } else {
       ss2k->lastDebounceTime = 0;


### PR DESCRIPTION
- Fixes homing not being removed after powertable reset.
- Shifting will always abort homing, even if homing hasn't been preformed yet.