### PR TITLE
Correct Cycling Power And CSC Feature Characteristics 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fixed flags in CPS and CSC which were causing issues in GTA Bike. Thanks @matthewsshirley !
 
 ### Hardware
 

--- a/include/BLE_Cycling_Power_Service.h
+++ b/include/BLE_Cycling_Power_Service.h
@@ -21,4 +21,5 @@ class BLE_Cycling_Power_Service {
   BLECharacteristic *cyclingPowerMeasurementCharacteristic;
   BLECharacteristic *cyclingPowerFeatureCharacteristic;
   BLECharacteristic *sensorLocationCharacteristic;
+  byte cpFeature[4] = {0, 0, 0, 0};
 };

--- a/include/BLE_Cycling_Speed_Cadence.h
+++ b/include/BLE_Cycling_Speed_Cadence.h
@@ -21,4 +21,5 @@ class BLE_Cycling_Speed_Cadence {
   BLECharacteristic *cscMeasurement;
   BLECharacteristic *cscFeature;
   BLECharacteristic *cscControlPoint;
+  byte cscFeatureBytes[2] = {0, 0};
 };

--- a/include/BLE_Definitions.h
+++ b/include/BLE_Definitions.h
@@ -12,7 +12,7 @@ struct FitnessMachineIndoorBikeDataFlags {
   enum Types : uint16_t {
     MoreDataBit                 = 1U << 0,
     AverageSpeedPresent         = 1U << 1,
-    InstantaneousCadencePresent = 1U << 2,    
+    InstantaneousCadencePresent = 1U << 2,
     AverageCadencePresent       = 1U << 3,
     TotalDistancePresent        = 1U << 4,
     ResistanceLevelPresent      = 1U << 5,
@@ -191,6 +191,27 @@ struct FtmsStatus {
   int length;
 };
 
+// https://www.bluetooth.com/specifications/specs/cpp-1-1-html/
+// See "4.4. Cycling Power Feature"
+struct CyclingPowerFeatureFlags {
+  enum Types : uint32_t {
+    PedalPowerBalanceSupported           = 1U << 0,
+    AccumulatedTorqueSupported           = 1U << 1,
+    WheelRevolutionDataSupported         = 1U << 2,
+    CrankRevolutionDataSupported         = 1U << 3,
+    ExtremeMagnitudesSupported           = 1U << 4,
+    ExtremesAnglesSupported              = 1U << 5,
+    TopBottomDeadSpotAnglesSupported     = 1U << 6,
+    AccumulatedEnergySupported           = 1U << 7,
+    ExtremeTorquesSupported              = 1U << 8,
+    OffsetCompensationIndicatorSupported = 1U << 9,
+  };
+};
+
+inline CyclingPowerFeatureFlags::Types operator|(CyclingPowerFeatureFlags::Types a, CyclingPowerFeatureFlags::Types b) {
+  return static_cast<CyclingPowerFeatureFlags::Types>(static_cast<int>(a) | static_cast<int>(b));
+}
+
 class CyclingPowerMeasurement {
  public:
   // Flags definition as per specification
@@ -255,6 +276,21 @@ class CyclingPowerMeasurement {
     return data;
   }
 };
+
+// https://www.bluetooth.com/specifications/specs/cscs-1-0/
+// See "3.2. CSC Feature"
+struct CyclingSpeedCadenceFeatureFlags {
+  enum Types : uint16_t {
+    WheelRevolutionDataSupported     = 1U << 0,
+    CrankRevolutionDataSupported     = 1U << 1,
+    MultipleSensorLocationsSupported = 1U << 2
+    // 3-15: Reserved for Future Use
+  };
+};
+
+inline CyclingSpeedCadenceFeatureFlags::Types operator|(CyclingSpeedCadenceFeatureFlags::Types a, CyclingSpeedCadenceFeatureFlags::Types b) {
+  return static_cast<CyclingSpeedCadenceFeatureFlags::Types>(static_cast<int>(a) | static_cast<int>(b));
+}
 
 class CscMeasurement {
  public:

--- a/src/BLE_Cycling_Power_Service.cpp
+++ b/src/BLE_Cycling_Power_Service.cpp
@@ -16,7 +16,15 @@ void BLE_Cycling_Power_Service::setupService(NimBLEServer *pServer, MyCallbacks 
   cyclingPowerFeatureCharacteristic     = pPowerMonitor->createCharacteristic(CYCLINGPOWERFEATURE_UUID, NIMBLE_PROPERTY::READ);
   sensorLocationCharacteristic          = pPowerMonitor->createCharacteristic(SENSORLOCATION_UUID, NIMBLE_PROPERTY::READ);
   byte cpsLocation[1]                   = {0b0101};    // sensor location 5 == left crank
-  byte cpFeature[1]                     = {0b001100};  // crank information & wheel revolution data present
+
+  CyclingPowerFeatureFlags::Types cpFeatureFlags = CyclingPowerFeatureFlags::WheelRevolutionDataSupported |
+                                                   CyclingPowerFeatureFlags::CrankRevolutionDataSupported;
+
+  cpFeature[0] = static_cast<uint8_t>(cpFeatureFlags & 0xFF);
+  cpFeature[1] = static_cast<uint8_t>((cpFeatureFlags >> 8) & 0xFF);
+  cpFeature[2] = static_cast<uint8_t>((cpFeatureFlags >> 16) & 0xFF);
+  cpFeature[3] = static_cast<uint8_t>((cpFeatureFlags >> 24) & 0xFF);
+
   cyclingPowerFeatureCharacteristic->setValue(cpFeature, sizeof(cpFeature));
   sensorLocationCharacteristic->setValue(cpsLocation, sizeof(cpsLocation));
   cyclingPowerMeasurementCharacteristic->setCallbacks(chrCallbacks);

--- a/src/BLE_Cycling_Speed_Cadence.cpp
+++ b/src/BLE_Cycling_Speed_Cadence.cpp
@@ -14,8 +14,14 @@ void BLE_Cycling_Speed_Cadence::setupService(NimBLEServer *pServer, MyCallbacks 
   pCyclingSpeedCadenceService = pServer->createService(CSCSERVICE_UUID);
   cscMeasurement              = pCyclingSpeedCadenceService->createCharacteristic(CSCMEASUREMENT_UUID, NIMBLE_PROPERTY::NOTIFY);
   cscFeature                  = pCyclingSpeedCadenceService->createCharacteristic(CSCFEATURE_UUID, NIMBLE_PROPERTY::READ);
-  byte cscFeatureFlags[1]     = {0b11};
-  cscFeature->setValue(cscFeatureFlags, sizeof(cscFeatureFlags));
+  
+  CyclingSpeedCadenceFeatureFlags::Types cscFeatureFlags = CyclingSpeedCadenceFeatureFlags::WheelRevolutionDataSupported | 
+                                                           CyclingSpeedCadenceFeatureFlags::CrankRevolutionDataSupported;
+
+  cscFeatureBytes[0] = static_cast<uint8_t>(cscFeatureFlags & 0xFF);
+  cscFeatureBytes[1] = static_cast<uint8_t>((cscFeatureFlags >> 8) & 0xFF);
+
+  cscFeature->setValue(cscFeatureBytes, sizeof(cscFeatureBytes));
   cscMeasurement->setCallbacks(chrCallbacks);
   pCyclingSpeedCadenceService->start();
 }


### PR DESCRIPTION


It was reported that GTBikeV crashes when a SmartSpin2k device connects as the length of the Cycling Power feature characteristic is only 1-byte. As noted in the following [comment](https://github.com/doudar/SmartSpin2k/issues/630#issuecomment-2719457987), this characteristic should be 4-bytes.

Therefore, this PR updates the Cycling Power feature characteristic to be 4 bytes, with the 2nd and 3rd bit flagged. I additionally updated the Cycling Speed Cadence, which is supposed to be 2 bytes. However, the last byte is reserved, so I doubt any applications struggle with handling this.

PR resolves #630. 