### PR TITLE
Fix Peloton serial homing range and post-homing starting gear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fix Peloton serial homing to use resistance feedback instead of StallGuard sensorless detection.
+  StallGuard fired prematurely on Peloton's continuously-increasing magnetic resistance, causing
+  hMax to be set at ~50% of the actual physical travel range. pelotonConnected() now sets
+  resistance.setMin/setMax (the homing target bounds) so that _findFTMSHome() receives valid
+  targets, and goHome() now includes ss2k->pelotonIsConnected in its FTMS homing condition so
+  Peloton serial users take the resistance-feedback path rather than falling through to StallGuard.
+- Replace hardcoded post-homing gear 8 with a calculated midpoint (hMax / (2 * shiftStep)).
+  The hardcoded value assumed a correctly-ranged hMax; for Peloton serial users whose hMax was
+  only ~50% of physical range, starting at gear 8 left no room to shift up. The calculated
+  value places the motor at the center of the actual calibrated travel range.
 
 ### Hardware
 

--- a/src/BLE_Client.cpp
+++ b/src/BLE_Client.cpp
@@ -239,7 +239,8 @@ void bleClientTask(void* pvParameters) {
           ss2k->goHome(true);
         } else {  // Startup Homing
           ss2k->goHome(false);
-          rtConfig->setShifterPosition(8);  // Set to middle position after homing on startup
+          int startGear = (userConfig->getShiftStep() > 0) ? (userConfig->getHMax() / (2 * userConfig->getShiftStep())) : 4;
+          rtConfig->setShifterPosition(startGear > 0 ? startGear : 0);  // Start at ~midpoint of calibrated travel range
         }
         spinBLEServer.spinDownFlag = 0;
       }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -812,8 +812,8 @@ void SS2K::goHome(bool bothDirections) {
     }
   }
 
-  // if we're using real resistance from a FTMS bike, find those values for the reported min and max resistance instead of using hard stops.
-  if (!rtConfig->resistance.getSimulate() && userConfig->getConnectedPowerMeter() != NONE && rtConfig->resistance.getMax() > 0) {
+  // if we're using real resistance from a FTMS bike or Peloton serial, use resistance feedback for homing instead of hard stops.
+  if (!rtConfig->resistance.getSimulate() && (userConfig->getConnectedPowerMeter() != NONE || ss2k->pelotonIsConnected) && rtConfig->resistance.getMax() > 0) {
     ss2k->_findFTMSHome(bothDirections);
     if (rtConfig->getHomed()) {
       fitnessMachineService.spinDown(FitnessMachineStatus::SpinDown_Success);
@@ -955,6 +955,8 @@ bool SS2K::pelotonConnected() {
   if (millis() - rtConfig->resistance.getTimestamp() < 5000 && !rtConfig->resistance.getSimulate()) {
     rtConfig->setMinResistance(MIN_PELOTON_RESISTANCE);
     rtConfig->setMaxResistance(MAX_PELOTON_RESISTANCE);
+    rtConfig->resistance.setMin(MIN_PELOTON_RESISTANCE);
+    rtConfig->resistance.setMax(MAX_PELOTON_RESISTANCE);
     return true;
   } else {
     rtConfig->setMinResistance(-DEFAULT_RESISTANCE_RANGE);


### PR DESCRIPTION
## Problem

Peloton serial users could not shift up in Zwift free-ride (sim) mode after the Jan 2 2026 commit that set gear 8 as the post-homing position. The root cause is two gaps in the Peloton serial homing path:

1. `pelotonConnected()` set the shift-blocking bounds (`setMinResistance` / `setMaxResistance`) but never called `resistance.setMin/setMax`, so `_findFTMSHome()` always saw `resistance.getMax() == 0` and skipped resistance-feedback homing entirely for serial Peloton users.

2. `goHome()` required `connectedPowerMeter != NONE` to take the resistance-feedback path, but serial Peloton has no BLE power meter. It fell through to StallGuard sensorless detection, which fires prematurely due to the Peloton's continuously-increasing magnetic resistance — leaving hMax at ~50% of the actual physical travel range.

Starting at gear 8 against a half-range hMax left no room to shift up.

## Fix (3 changes, 1 commit)

- **`pelotonConnected()`**: also call `resistance.setMin/setMax` so `_findFTMSHome()` receives valid `[5, 98]` resistance targets.
- **`goHome()`**: extend FTMS homing condition to include `ss2k->pelotonIsConnected`, routing serial Peloton through resistance-feedback homing instead of StallGuard.
- **`BLE_Client` startup**: replace hardcoded `setShifterPosition(8)` with `hMax / (2 * shiftStep)`, placing the motor at the center of the actual calibrated travel range regardless of bike type.

## Hardware tested

Validated on a physical Peloton with SmartSpin2k connected via serial (not BLE). After flashing and a Zwift spindown calibration:
- hMax corrected from ~12,698 to ~21,638 steps (full physical travel range)
- Full up and down shifting confirmed in Zwift free-ride mode
- Spindown calibration persists the correct hMax to config

## Notes

- The two pre-existing native test failures (`test_parses_cadence`, `test_fill_incomplete_table`) are present on the current `develop` tip and are unrelated to these changes.
- This fix was developed with AI assistance (Claude Sonnet 4.6, Anthropic). The `Co-Authored-By` trailer in the commit reflects this. All changes were reviewed and validated on hardware before submission.