### PR TITLE
fixes to address 0 brake watts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Hardware
 
 
+## [26.9.5]
+
+### Added
+
+### Changed
+
+### Hardware
+
+
 ## [26.8.23]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fix handling of 0 value in min and max brake watts settings so they persist correctly. Correct ERG shift behavior when max brake watts is set to unlimited (0).
 
 ### Hardware
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -547,7 +547,10 @@ void SS2K::FTMSModeShiftModifier() {
         rtConfig->setShifterPosition(ss2k->lastShifterPosition);  // reset shifter position because we're remapping it to ERG target
         const int proposedTarget = rtConfig->watts.getTarget() + (shiftDelta * ERG_PER_SHIFT);
         const int minimumTarget  = rtConfig->getHomed() ? 0 : userConfig->getMinWatts();
-        if (proposedTarget < minimumTarget || proposedTarget > userConfig->getMaxWatts()) {
+        const int maximumTarget  = userConfig->getMaxWatts();
+        const bool belowMinimum  = shiftDelta < 0 && proposedTarget < minimumTarget;
+        const bool aboveMaximum  = shiftDelta > 0 && maximumTarget > 0 && proposedTarget > maximumTarget;
+        if (belowMinimum || aboveMaximum) {
           SS2K_LOG(MAIN_LOG_TAG, "Shift to %dw blocked", proposedTarget);
           break;
         }

--- a/src/Power_Table.cpp
+++ b/src/Power_Table.cpp
@@ -89,12 +89,12 @@ void PowerTable::setStepperMinMax() {
   int32_t _return = RETURN_ERROR;
 
   // if Homing was preformed, skip estimating min_max
-  if (rtConfig->getHomed() && (userConfig->getHMin() != INT32_MIN) || (userConfig->getHMax() != INT32_MIN)) {
+  if (rtConfig->getHomed() && userConfig->getHMin() != INT32_MIN && userConfig->getHMax() != INT32_MIN) {
     SS2K_LOG(POWERTABLE_LOG_TAG, "Using detected travel limits during homing");
     rtConfig->setMinStep(userConfig->getHMin());
     rtConfig->setMaxStep(userConfig->getHMax());
     return;
-  } else if (rtConfig->getHomed()){
+  } else if (rtConfig->getHomed()) {
     SS2K_LOG(POWERTABLE_LOG_TAG, "HOMING VALUES NOT FOUND");
   }
 

--- a/src/SmartSpin_parameters.cpp
+++ b/src/SmartSpin_parameters.cpp
@@ -212,13 +212,13 @@ JsonDocument doc;
   if (doc["ERGSensitivity"]) {
     setERGSensitivity(doc["ERGSensitivity"]);
   }
-  if (doc["maxWatts"]) {
+  if (!doc["maxWatts"].isNull()) {
     setMaxWatts(doc["maxWatts"]);
   }
   if (doc["stepperSpeed"]) {
     setStepperSpeed(doc["stepperSpeed"]);
   }
-  if (doc["minWatts"]) {
+  if (!doc["minWatts"].isNull()) {
     setMinWatts(doc["minWatts"]);
   }
   if (!doc["stepperDir"].isNull()) {


### PR DESCRIPTION
## Summary
- `SmartSpin_parameters.cpp`: `maxWatts`/`minWatts` were read from JSON with check (`if (doc["maxWatts"])`), so a value of `0` was silently ignored instead of being applied. Switched to `!doc["maxWatts"].isNull()` so `0` is accepted.
- `Power_Table.cpp`: `setStepperMinMax()` had an operator-precedence bug (`homed && (a) || (b)`) that let it use homing travel limits even when only one of `HMin`/`HMax` was actually set (or when not homed). Now requires `homed && HMin set && HMax set`.
- `Main.cpp`: `FTMSModeShiftModifier()` blocked ERG shifts any time the proposed target exceeded `maxWatts`, even when `maxWatts == 0` (meaning "unlimited"), and blocked regardless of shift direction. Now only checks the minimum bound when shifting down and only checks the maximum bound when shifting up and `maxWatts > 0`.

## Test plan
- [ ] Set `minWatts`/`maxWatts` to `0` via the web UI and confirm the values persist after save/reload.
- [ ] With `maxWatts = 0` (unlimited), verify ERG shift-up via shifters is no longer blocked.
- [ ] Verify shift-down is still blocked below `minWatts` and shift-up is still blocked above a non-zero `maxWatts`.
- [ ] Confirm stepper min/max homing limits still apply correctly when both `HMin` and `HMax` are set from a prior homing run.
